### PR TITLE
[PSYS-93] Set `amountSurcharge` as `int`

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -161,4 +161,17 @@ abstract class AbstractRequest extends CommonAbstractRequest
     {
         return substr((string) preg_replace('/[^a-zA-Z0-9 \-]/', '', (string) $string), 0, $maxLength);
     }
+
+    protected function setParameterAsInt(string $key, string|int|null $value, bool $removeNull = false): self
+    {
+        if ($removeNull && $value === null) {
+            $this->parameters->remove($key);
+        } elseif ($value !== null) {
+            $this->parameters->set($key, (int) $value);
+        } else {
+            $this->parameters->set($key, null);
+        }
+
+        return $this;
+    }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -79,14 +79,14 @@ class PurchaseRequest extends AbstractRequest
         return parent::getEndpointBase() . '/txns';
     }
 
-    public function getAmountSurcharge(): ?string
+    public function getAmountSurcharge(): ?int
     {
         return $this->getParameter('amountSurcharge');
     }
 
-    public function setAmountSurcharge(string $value): AbstractRequest
+    public function setAmountSurcharge(string|int|null $value): AbstractRequest
     {
-        return $this->setParameter('amountSurcharge', $value);
+        return $this->setParameterAsInt('amountSurcharge', $value, true);
     }
 
     protected function createResponse(mixed $data): PurchaseResponse


### PR DESCRIPTION
### Fix PSYS-93
Link to ticket: https://digistorm.atlassian.net/browse/PSYS-93

The BPOINT api expects `amountSurcharge` to be an `int`.